### PR TITLE
Fix Storage Endpoint Suffix

### DIFF
--- a/src/ResourceManager/Compute/Commands.Compute/Microsoft.Azure.Commands.Compute.dll-Help.xml
+++ b/src/ResourceManager/Compute/Commands.Compute/Microsoft.Azure.Commands.Compute.dll-Help.xml
@@ -3076,7 +3076,14 @@ $ext = Get-AzureVMCustomScriptExtension -ResourceGroupName $rgname -VMName $vmna
 				</maml:description>
 				<command:parameterValue required="true" variableLength="false">String</command:parameterValue>
 			</command:parameter>
-			<command:parameter required="false" variableLength="false" globbing="false" pipelineInput="false" position="named">
+            <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="false" position="named">
+              <maml:name>StorageEndpointSuffix</maml:name>
+              <maml:description>
+                <maml:para>Suffix for the storage end point, e.g. core.windows.net</maml:para>
+              </maml:description>
+              <command:parameterValue required="true" variableLength="false">string</command:parameterValue>
+            </command:parameter>
+          <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="false" position="named">
 				<maml:name>WhatIf</maml:name>
 				<maml:description>
 					<maml:para>Describes what would happen if you executed the command without actually executing the command.</maml:para>
@@ -3187,7 +3194,20 @@ When this parameter is used, the configuration script is not uploaded to Azure b
 			</dev:type>
 			<dev:defaultValue></dev:defaultValue>
 		</command:parameter>
-		<command:parameter required="false" variableLength="false" globbing="false" pipelineInput="false" position="named">
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="false" position="named">
+          <maml:name>StorageEndpointSuffix</maml:name>
+          <maml:description>
+            <maml:para>Suffix for the storage end point, e.g. core.windows.net</maml:para>
+
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">string</command:parameterValue>
+          <dev:type>
+            <maml:name>string</maml:name>
+            <maml:uri/>
+          </dev:type>
+          <dev:defaultValue></dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="false" position="named">
 			<maml:name>WhatIf</maml:name>
 			<maml:description>
 				<maml:para>Describes what would happen if you executed the command without actually executing the command.</maml:para>

--- a/src/ServiceManagement/Compute/Commands.ServiceManagement/Microsoft.WindowsAzure.Commands.ServiceManagement.dll-Help.xml
+++ b/src/ServiceManagement/Compute/Commands.ServiceManagement/Microsoft.WindowsAzure.Commands.ServiceManagement.dll-Help.xml
@@ -17571,7 +17571,6 @@ When this parameter is used, the configuration script is not uploaded to Azure b
           <maml:name>StorageEndpointSuffix</maml:name>
           <maml:description>
             <maml:para>Suffix for the storage end point, e.g. core.windows.net</maml:para>
-
           </maml:description>
           <command:parameterValue required="true" variableLength="false">string</command:parameterValue>
           <dev:type>

--- a/src/ServiceManagement/Compute/Commands.ServiceManagement/Microsoft.WindowsAzure.Commands.ServiceManagement.dll-Help.xml
+++ b/src/ServiceManagement/Compute/Commands.ServiceManagement/Microsoft.WindowsAzure.Commands.ServiceManagement.dll-Help.xml
@@ -17456,7 +17456,14 @@ New-AzureDeployment -ServiceName $cloudSvc -Slot Production -Package $pkg -Confi
 				</maml:description>
 				<command:parameterValue required="true" variableLength="false">AzureStorageContext</command:parameterValue>
 			</command:parameter>
-			<command:parameter required="false" variableLength="false" globbing="false" pipelineInput="false" position="named">
+            <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="true (ByPropertyName)" position="named">
+                <maml:name>StorageEndpointSuffix</maml:name>
+                <maml:description>
+                    <maml:para>Suffix for the storage end point, e.g. core.windows.net</maml:para>
+                </maml:description>
+                <command:parameterValue required="true" variableLength="false">string</command:parameterValue>
+            </command:parameter>
+          <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="false" position="named">
 				<maml:name>WhatIf</maml:name>
 				<maml:description>
 					<maml:para>Describes what would happen if you executed the command without actually executing the command.</maml:para>
@@ -17560,7 +17567,20 @@ When this parameter is used, the configuration script is not uploaded to Azure b
 			</dev:type>
 			<dev:defaultValue></dev:defaultValue>
 		</command:parameter>
-		<command:parameter required="false" variableLength="false" globbing="false" pipelineInput="false" position="named">
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="true (ByPropertyName)" position="named">
+          <maml:name>StorageEndpointSuffix</maml:name>
+          <maml:description>
+            <maml:para>Suffix for the storage end point, e.g. core.windows.net</maml:para>
+
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">string</command:parameterValue>
+          <dev:type>
+            <maml:name>string</maml:name>
+            <maml:uri/>
+          </dev:type>
+          <dev:defaultValue></dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="false" position="named">
 			<maml:name>WhatIf</maml:name>
 			<maml:description>
 				<maml:para>Describes what would happen if you executed the command without actually executing the command.</maml:para>


### PR DESCRIPTION
The Storage Endpoint Suffix was missing from Publish and was not used in Set, so we were always trying to use Public Azure.

With this fix now we can use Mooncake and Gov.